### PR TITLE
Fix Voxel Cone Tracing technique shader compilation error

### DIFF
--- a/Assets/Shaders/Voxelize/voxelizeFragment.glsl
+++ b/Assets/Shaders/Voxelize/voxelizeFragment.glsl
@@ -31,38 +31,6 @@ in vec2 geom_texcoord;
 in mat3 geom_swizzleMatrixInv;
 in vec4 geom_BBox;
 
-/*
- * Thanks to: https://rauwendaal.net/2013/02/07/glslrunningaverage/
-*/
-
-void ImageAtomicAverageRGBA8(layout(r32ui) coherent volatile uimage3D voxels, ivec3 coord, vec3 nextVec3)
-{
-    uint nextUint = packUnorm4x8 (vec4 (nextVec3, 1.0f / 255.0f));
-    uint prevUint = 0;
-    uint currUint;
- 
-    vec4 currVec4;
- 
-    vec3 average;
-    uint count;
- 
-    //"Spin" while threads are trying to change the voxel
-    while((currUint = imageAtomicCompSwap(voxels, coord, prevUint, nextUint)) != prevUint)
-    {
-        prevUint = currUint;                    //store packed rgb average and count
-        currVec4 = unpackUnorm4x8(currUint);    //unpack stored rgb average and count
- 
-        average =      currVec4.rgb;        //extract rgb average
-        count   = uint(currVec4.a * 255.0f);  //extract count
- 
-        //Compute the running average
-        average = (average*count + nextVec3) / (count + 1);
- 
-        //Pack new average and incremented count back into a uint
-        nextUint = packUnorm4x8(vec4(average, (count + 1) / 255.0f));
-    }
-}
-
 void main()
 {
 	/*
@@ -99,6 +67,4 @@ void main()
 	} else {
 		imageStore (voxelVolume, ivec3 (coords), vec4 (fragmentColor, 1.0 - MaterialTransparency));
 	}
-
-	// ImageAtomicAverageRGBA8 (voxelVolume, ivec3 (coords), fragmentColor);
 }


### PR DESCRIPTION
Removed unused function from Voxelize fragment shader, which failed to compile because of GLSL syntax error (close #1).